### PR TITLE
Subscribe to the default pool when subscribing to a sys topic

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,10 @@ Note that this library does not handle TCP/IP connections. It handles the
 complete MQTT session logic. Other libraries are used for transporting the
 MQTT packets to/from external clients.
 
+When a subscription is made to a $SYS topic the subscriber is mapped to
+the default pool. This makes it possible to share system information
+between different pools.
+
 ### TODO
 
 1. Add protections

--- a/src/mqtt_sessions.erl
+++ b/src/mqtt_sessions.erl
@@ -34,6 +34,9 @@
     fetch_queue/1,
     fetch_queue/2,
 
+    count_sessions/1,
+    router_info/1,
+
     get_user_context/1,
     get_user_context/2,
     set_user_context/2,
@@ -133,6 +136,13 @@ find_session( ClientId ) ->
 find_session(Pool, ClientId) ->
     mqtt_sessions_registry:find_session(Pool, ClientId).
 
+-spec count_sessions( atom() ) -> integer.
+count_sessions(Pool) ->
+    mqtt_sessions_process_sup:count_sessions(Pool).
+
+-spec router_info( atom() ) -> list().
+router_info(Pool) ->
+    mqtt_sessions_router:info(Pool).
 
 -spec fetch_queue( session_ref() ) -> {ok, list( mqtt_packet_map:mqtt_message() | binary() )} | {error, notfound}.
 fetch_queue(ClientId) ->

--- a/src/mqtt_sessions.erl
+++ b/src/mqtt_sessions.erl
@@ -34,7 +34,7 @@
     fetch_queue/1,
     fetch_queue/2,
 
-    count_sessions/1,
+    session_count/1,
     router_info/1,
 
     get_user_context/1,
@@ -136,9 +136,9 @@ find_session( ClientId ) ->
 find_session(Pool, ClientId) ->
     mqtt_sessions_registry:find_session(Pool, ClientId).
 
--spec count_sessions( atom() ) -> integer.
-count_sessions(Pool) ->
-    mqtt_sessions_process_sup:count_sessions(Pool).
+-spec session_count( atom() ) -> integer.
+session_count(Pool) ->
+    mqtt_sessions_process_sup:session_count(Pool).
 
 -spec router_info( atom() ) -> list().
 router_info(Pool) ->

--- a/src/mqtt_sessions_process_sup.erl
+++ b/src/mqtt_sessions_process_sup.erl
@@ -26,7 +26,7 @@
     start_link/1,
     init/1,
     name/1,
-    count_sessions/1
+    session_count/1
     ]).
 
 
@@ -38,8 +38,8 @@ new_session(Pool, ClientId, SessionOptions) when is_binary(ClientId) ->
     {ok, Pid} = supervisor:start_child(name(Pool), [ ClientId, SessionOptions ]),
     {ok, {Pid, ClientId}}.
 
--spec count_sessions( atom() ) -> integer().
-count_sessions(Pool) ->
+-spec session_count( atom() ) -> integer().
+session_count(Pool) ->
     Props = supervisor:count_children(name(Pool)),
     {active, N} = proplists:lookup(active, Props),
     N.

--- a/src/mqtt_sessions_process_sup.erl
+++ b/src/mqtt_sessions_process_sup.erl
@@ -25,7 +25,8 @@
     new_session/3,
     start_link/1,
     init/1,
-    name/1
+    name/1,
+    count_sessions/1
     ]).
 
 
@@ -36,6 +37,12 @@ new_session(Pool, <<>>, SessionOptions) ->
 new_session(Pool, ClientId, SessionOptions) when is_binary(ClientId) ->
     {ok, Pid} = supervisor:start_child(name(Pool), [ ClientId, SessionOptions ]),
     {ok, {Pid, ClientId}}.
+
+-spec count_sessions( atom() ) -> integer().
+count_sessions(Pool) ->
+    Props = supervisor:count_children(name(Pool)),
+    {active, N} = proplists:lookup(active, Props),
+    N.
 
 -spec start_link( atom() ) -> {ok, pid()} | {error, term()}.
 start_link( Pool ) ->

--- a/src/mqtt_sessions_router.erl
+++ b/src/mqtt_sessions_router.erl
@@ -28,7 +28,8 @@
     unsubscribe/3,
     unsubscribe_pid/2,
     start_link/1,
-    name/1
+    name/1,
+    info/1
     ]).
 
 -export([
@@ -262,6 +263,10 @@ remove_subscriber(Pid, #state{ router = Router, monitors = Monitors } = State) -
 -spec name( atom() ) -> atom().
 name( Pool ) ->
     list_to_atom(atom_to_list(Pool) ++ "$router").
+
+-spec info( atom() ) -> list().
+info( Pool ) ->
+    router:info(Pool).
 
 %% @doc For subscribtions to a $SYS topic, we map to the default pool.
 -spec maybe_map_to_default_pool( atom(), mqtt_sessions:topic()) -> atom().


### PR DESCRIPTION
When a subscriber wants to subscribe to a $SYS topic, it will subscribe to the default pool instead of their own pool.