### PR TITLE
Put the validated topic into the message, this fixes retained message publishing

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -18,14 +18,14 @@ jobs:
 
     strategy:
       matrix:
-        otp_version: [23, 24, 25]
+        otp_version: [24, 25, 26]
         os: [ubuntu-latest]
 
     container:
       image: erlang:${{ matrix.otp_version }}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - name: Compile
         run: make
       - name: Test

--- a/src/mqtt_sessions.app.src
+++ b/src/mqtt_sessions.app.src
@@ -7,7 +7,9 @@
         kernel, stdlib, crypto,
         sidejob,
         router,
-        mqtt_packet_map
+        zotonic_stdlib,
+        mqtt_packet_map,
+        jsx
     ]},
     {env, [
         {runtime, mqtt_sessions_runtime},

--- a/src/mqtt_sessions.erl
+++ b/src/mqtt_sessions.erl
@@ -203,9 +203,10 @@ publish(Pool, #{ type := publish, topic := Topic } = Msg, UserContext) when is_a
     case mqtt_packet_map_topic:validate_topic_publish(Topic) of
         {ok, TopicValidated} ->
             Runtime = runtime(),
-            case Runtime:is_allowed(publish, TopicValidated, Msg, UserContext) of
+            MsgValidatedTopic = Msg#{ topic => TopicValidated },
+            case Runtime:is_allowed(publish, TopicValidated, MsgValidatedTopic, UserContext) of
                 true ->
-                    case mqtt_sessions_router:publish(Pool, TopicValidated, Msg, UserContext) of
+                    case mqtt_sessions_router:publish(Pool, TopicValidated, MsgValidatedTopic, UserContext) of
                         {ok, _Pid} -> ok;
                         {error, _} = Error -> Error
                     end;

--- a/src/mqtt_sessions.erl
+++ b/src/mqtt_sessions.erl
@@ -144,11 +144,11 @@ session_count(Pool) ->
 router_info(Pool) ->
     mqtt_sessions_router:info(Pool).
 
--spec fetch_queue( session_ref() ) -> {ok, list( mqtt_packet_map:mqtt_message() | binary() )} | {error, notfound}.
+-spec fetch_queue( session_ref() ) -> {ok, list( mqtt_packet_map:mqtt_packet() | binary() )} | {error, notfound}.
 fetch_queue(ClientId) ->
     fetch_queue(?MQTT_SESSIONS_DEFAULT, ClientId).
 
--spec fetch_queue( atom(), session_ref() ) -> {ok, list( mqtt_packet_map:mqtt_message() | binary() )} | {error, notfound}.
+-spec fetch_queue( atom(), session_ref() ) -> {ok, list( mqtt_packet_map:mqtt_packet() | binary() )} | {error, notfound}.
 fetch_queue(Pool, ClientId) ->
     case find_session(Pool, ClientId) of
         {ok, Pid} -> mqtt_sessions_process:fetch_queue(Pid);
@@ -192,13 +192,13 @@ update_user_context(Pool, ClientId, Fun) ->
 get_transport(SessionPid) ->
     mqtt_sessions_process:get_transport(SessionPid).
 
--spec publish( mqtt_packet_map:mqtt_message(), term() ) -> ok | {error, eacces | invalid_topic}.
+-spec publish( mqtt_packet_map:mqtt_packet(), term() ) -> ok | {error, eacces | invalid_topic}.
 publish(#{ type := publish } = Msg, UserContext) ->
     publish(?MQTT_SESSIONS_DEFAULT, Msg, UserContext).
 
 -spec publish
         ( topic(), term(), term() ) -> ok | {error, eacces | invalid_topic};
-        ( atom(), mqtt_packet_map:mqtt_message(), term() ) -> ok | {error, eacces | invalid_topic}.
+        ( atom(), mqtt_packet_map:mqtt_packet(), term() ) -> ok | {error, eacces | invalid_topic}.
 publish(Pool, #{ type := publish, topic := Topic } = Msg, UserContext) when is_atom(Pool) ->
     case mqtt_packet_map_topic:validate_topic_publish(Topic) of
         {ok, TopicValidated} ->
@@ -307,13 +307,13 @@ temp_response_topic(Pool, UserContext) ->
             end
     end.
 
--spec await_response( topic() ) -> {ok, mqtt_packet_map:mqtt_message()} | {error, timeout}.
+-spec await_response( topic() ) -> {ok, mqtt_packet_map:mqtt_packet()} | {error, timeout}.
 await_response( Topic ) ->
     await_response(?MQTT_SESSIONS_DEFAULT, Topic).
 
 -spec await_response
-    ( topic(), pos_integer() ) -> {ok, mqtt_packet_map:mqtt_message()} | {error, timeout};
-    ( atom(), topic() ) -> {ok, mqtt_packet_map:mqtt_message()} | {error, timeout}.
+    ( topic(), pos_integer() ) -> {ok, mqtt_packet_map:mqtt_packet()} | {error, timeout};
+    ( atom(), topic() ) -> {ok, mqtt_packet_map:mqtt_packet()} | {error, timeout}.
 
 await_response( Topic, Timeout ) when is_list(Topic), is_integer(Timeout) ->
     await_response(?MQTT_SESSIONS_DEFAULT, Topic, Timeout);

--- a/src/mqtt_sessions_job.erl
+++ b/src/mqtt_sessions_job.erl
@@ -31,7 +31,7 @@
 -include_lib("router/include/router.hrl").
 -include_lib("../include/mqtt_sessions.hrl").
 
--spec publish( atom(), mqtt_sessions:topic(), list(), mqtt_packet_map:mqtt_message(), term()) -> {ok, pid() | undefined} | {error, overload}.
+-spec publish( atom(), mqtt_sessions:topic(), list(), mqtt_packet_map:mqtt_packet(), term()) -> {ok, pid() | undefined} | {error, overload}.
 publish(_Pool, _Topic, [], _Msg, _PublisherContext) ->
     {ok, undefined};
 publish(Pool, Topic, Routes, Msg, PublisherContext) ->

--- a/src/mqtt_sessions_retain.erl
+++ b/src/mqtt_sessions_retain.erl
@@ -53,7 +53,7 @@
 start_link( Pool ) ->
     gen_server:start_link({local, name(Pool)}, ?MODULE, [Pool], []).
 
--spec retain( atom(), mqtt_packet_map:mqtt_message(), term() ) -> ok.
+-spec retain( atom(), mqtt_packet_map:mqtt_packet(), term() ) -> ok.
 retain(Pool, #{ type := publish, topic := Topic } = Msg, PublisherContext) when is_list(Topic) ->
     case is_empty_payload(Msg) of
         true ->
@@ -62,7 +62,7 @@ retain(Pool, #{ type := publish, topic := Topic } = Msg, PublisherContext) when 
             gen_server:call(name(Pool), {retain, Msg, PublisherContext}, infinity)
     end.
 
--spec lookup( atom(), list(binary()) ) -> {ok, [ {mqtt_packet_map:mqtt_message(), term()} ]}.
+-spec lookup( atom(), list(binary()) ) -> {ok, [ {mqtt_packet_map:mqtt_packet(), term()} ]}.
 lookup(Pool, TopicFilter) ->
     case is_wildcard(TopicFilter) of
         true ->

--- a/src/mqtt_sessions_router.erl
+++ b/src/mqtt_sessions_router.erl
@@ -45,7 +45,7 @@
         pool => atom(),
         topic => list( binary() ),
         topic_bindings => list( proplists:property() ),
-        message => mqtt_packet_map:mqtt_message(),
+        message => mqtt_packet_map:mqtt_packet(),
         publisher_context => term(),
         subscriber_context => term(),
         no_local => boolean(),
@@ -64,9 +64,11 @@
 
 -type subscriber() :: {pid() | mfa(), OwnerPid::pid(), subscriber_options()}.
 
+
 -export_type([
     subscriber/0,
-    mqtt_msg/0
+    mqtt_msg/0,
+    subscriber_options/0
 ]).
 
 -record(state, {
@@ -79,11 +81,11 @@
 -include_lib("../include/mqtt_sessions.hrl").
 
 
--spec publish( atom(), list(), mqtt_packet_map:mqtt_message() ) -> {ok, pid() | undefined} | {error, overload}.
+-spec publish( atom(), list(), mqtt_packet_map:mqtt_packet() ) -> {ok, pid() | undefined} | {error, overload}.
 publish( Pool, Topic, Msg ) ->
     publish(Pool, Topic, Msg, undefined).
 
--spec publish( atom(), list(), mqtt_packet_map:mqtt_message(), term() ) -> {ok, pid() | undefined} | {error, overload}.
+-spec publish( atom(), list(), mqtt_packet_map:mqtt_packet(), term() ) -> {ok, pid() | undefined} | {error, overload}.
 publish( Pool, Topic0, Msg, PublisherContext ) ->
     Topic = publish_topic(Topic0),
     Routes = router:route(Pool, Topic),

--- a/src/mqtt_sessions_runtime.erl
+++ b/src/mqtt_sessions_runtime.erl
@@ -76,7 +76,7 @@ new_user_context( Pool, ClientId, Options ) ->
 control_message(_Topic, _Packet, UserContext) ->
     {ok, UserContext}.
 
--spec connect( mqtt_packet_map:mqtt_packet(), boolean(), mqtt_session:msg_options(), user_context()) -> {ok, mqtt_packet_map:mqtt_packet(), user_context()} | {error, term()}.
+-spec connect( mqtt_packet_map:mqtt_packet(), boolean(), mqtt_sessions:msg_options(), user_context()) -> {ok, mqtt_packet_map:mqtt_packet(), user_context()} | {error, term()}.
 connect(#{ type := connect, username := U, password := P }, IsSessionPresent, Options, UserContext) when ?none(U), ?none(P) ->
     % Anonymous login - user must stay anonymous (regardless of IsSessionPresent)
     case maps:get(user, UserContext, undefined) of

--- a/test/mqtt_sessions_protocol_SUITE.erl
+++ b/test/mqtt_sessions_protocol_SUITE.erl
@@ -5,6 +5,12 @@
 -include_lib("common_test/include/ct.hrl").
 -include_lib("mqtt_sessions/include/mqtt_sessions.hrl").
 
+%% Supress dialyzer warings on using the ct module.
+-dialyzer({nowarn_function, connect_disconnect_v5_test/1}).
+-dialyzer({nowarn_function, connect_reconnect_v5_test/1}).
+-dialyzer({nowarn_function, connect_reconnect_clean_v5_test/1}).
+
+
 %%--------------------------------------------------------------------
 %% COMMON TEST CALLBACK FUNCTIONS
 %%--------------------------------------------------------------------


### PR DESCRIPTION

Put the normalized topic back into the original message. The message will now be stored normalized, and retained message matching will work.